### PR TITLE
adding @XmlRootElement for ModsDocument

### DIFF
--- a/src/main/java/edu/asu/lib/mods/ModsDocument.java
+++ b/src/main/java/edu/asu/lib/mods/ModsDocument.java
@@ -8,6 +8,7 @@ import java.util.List;
 import javax.xml.XMLConstants;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
+import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
@@ -19,6 +20,7 @@ import org.xml.sax.SAXException;
 import edu.asu.lib.jaxb.JaxbDocument;
 import gov.loc.mods.v3.ModsType;
 
+@XmlRootElement(name="mods", namespace=ModsDocument.MODS_SCHEMA_NAMESPACE)
 public class ModsDocument extends ModsElementContainer implements JaxbDocument {
     
     private static JAXBContext jaxbContext;


### PR DESCRIPTION
Hi Matt,
I've hit a small issue that requires the @XmlRootElement annotation on the ModsDocument if I remember that you're not using these libraries anymore, what's the best process for updating the published jar?  I'm happy to take ownership.

thanks,

adam
